### PR TITLE
フロントエンドのdetail画面を追加

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,31 +4,16 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from openai import OpenAI
 
-from starlette.middleware.cors import CORSMiddleware
 from chatgpt import clean_description, question_description, question_name
-from googlemap_api import (
-    get_cafe_restArea,
-    get_change_data,
-    get_convenienceStore_restArea,
-    get_place_all,
-    get_place_data,
-    get_toilet_restArea,
-)
+from googlemap_api import (get_cafe_restArea, get_change_data,
+                           get_convenienceStore_restArea, get_place_all,
+                           get_place_data, get_toilet_restArea)
 from request import MessageRequestBody, PlanRequestBody
 from response import MessageResponseBody, PlanResponseBody
 
-load_dotenv()
-
 app = FastAPI()
+load_dotenv()
 client = OpenAI()
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
 
 
 @app.post("/api/datePlan", response_model=MessageResponseBody)

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,16 +4,31 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from openai import OpenAI
 
+from starlette.middleware.cors import CORSMiddleware
 from chatgpt import clean_description, question_description, question_name
-from googlemap_api import (get_cafe_restArea, get_change_data,
-                           get_convenienceStore_restArea, get_place_all,
-                           get_place_data, get_toilet_restArea)
+from googlemap_api import (
+    get_cafe_restArea,
+    get_change_data,
+    get_convenienceStore_restArea,
+    get_place_all,
+    get_place_data,
+    get_toilet_restArea,
+)
 from request import MessageRequestBody, PlanRequestBody
 from response import MessageResponseBody, PlanResponseBody
 
-app = FastAPI()
 load_dotenv()
+
+app = FastAPI()
 client = OpenAI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.post("/api/datePlan", response_model=MessageResponseBody)

--- a/backend_mock/main.py
+++ b/backend_mock/main.py
@@ -65,11 +65,7 @@ def apiDatePlan(chatlogs: List[schemas.ChatLog] = Body(...)):
 def post_apiDatePlanRestArea(restAreas: schemas.apiDatePlanRestAreaRequestBody):
     """最寄りのトイレ・カフェ・コンビニの情報を返却する"""
     return {
-        "cafe": {
-            "name": "スタバ",
-            "latitude": 36.565273733041856,
-            "longitude": 136.66319108890323,
-        },
+        "cafe": {"name": "スタバ", "latitude": 0, "longitude": 0},
         "toilet": {"name": "公衆トイレ", "latitude": 0, "longitude": 0},
         "convenienceStore": {
             "name": "ファミリーマート0号",

--- a/backend_mock/main.py
+++ b/backend_mock/main.py
@@ -61,7 +61,7 @@ def apiDatePlan(chatlogs: List[schemas.ChatLog] = Body(...)):
 
 
 @app.post(
-    "api/datePlan/restArea", response_model=schemas.apiDatePlanRestAreaResponseBody
+    "/api/datePlan/restArea", response_model=schemas.apiDatePlanRestAreaResponseBody
 )
 def post_apiDatePlanRestArea(restAreas: schemas.apiDatePlanRestAreaRequestBody):
     """最寄りのトイレ・カフェ・コンビニの情報を返却する"""

--- a/backend_mock/main.py
+++ b/backend_mock/main.py
@@ -1,7 +1,6 @@
 from typing import List
-from time import sleep
 
-from fastapi import FastAPI, Body
+from fastapi import Body, FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
 import schemas

--- a/backend_mock/main.py
+++ b/backend_mock/main.py
@@ -58,3 +58,19 @@ def apiDatePlan(chatlogs: List[schemas.ChatLog] = Body(...)):
         ],
         "description": "これはテストです",
     }
+
+
+@app.post(
+    "api/datePlan/restArea", response_model=schemas.apiDatePlanRestAreaResponseBody
+)
+def post_apiDatePlanRestArea(restAreas: schemas.apiDatePlanRestAreaRequestBody):
+    """最寄りのトイレ・カフェ・コンビニの情報を返却する"""
+    return {
+        "cafe": {"name": "スタバ", "latitude": 0, "longitude": 0},
+        "toilet": {"name": "公衆トイレ", "latitude": 0, "longitude": 0},
+        "convenienceStore": {
+            "name": "ファミリーマート0号",
+            "latitude": 0,
+            "longitude": 0,
+        },
+    }

--- a/backend_mock/main.py
+++ b/backend_mock/main.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from fastapi import Body, FastAPI
+import schemas
 from starlette.middleware.cors import CORSMiddleware
 
 app = FastAPI()

--- a/backend_mock/main.py
+++ b/backend_mock/main.py
@@ -65,7 +65,11 @@ def apiDatePlan(chatlogs: List[schemas.ChatLog] = Body(...)):
 def post_apiDatePlanRestArea(restAreas: schemas.apiDatePlanRestAreaRequestBody):
     """最寄りのトイレ・カフェ・コンビニの情報を返却する"""
     return {
-        "cafe": {"name": "スタバ", "latitude": 0, "longitude": 0},
+        "cafe": {
+            "name": "スタバ",
+            "latitude": 36.565273733041856,
+            "longitude": 136.66319108890323,
+        },
         "toilet": {"name": "公衆トイレ", "latitude": 0, "longitude": 0},
         "convenienceStore": {
             "name": "ファミリーマート0号",

--- a/backend_mock/schemas.py
+++ b/backend_mock/schemas.py
@@ -31,3 +31,20 @@ class datePlanResponseBody(BaseModel):
 
     facilitys: List[Facility]
     description: str
+
+
+class apiDatePlanRestAreaRequestBody(Facility):
+    """
+    施設の情報を返却する
+    中身はFacilityクラスと同じなので、継承で済ませる
+    """
+
+
+class apiDatePlanRestAreaResponseBody(BaseModel):
+    """
+    カフェ・トイレ・コンビニの情報を返却する
+    """
+
+    cafe: Facility
+    toilet: Facility
+    convenienceStore: Facility

--- a/backend_mock/schemas.py
+++ b/backend_mock/schemas.py
@@ -31,4 +31,3 @@ class datePlanResponseBody(BaseModel):
 
     facilitys: List[Facility]
     description: str
-

--- a/frontend/makefile
+++ b/frontend/makefile
@@ -9,3 +9,5 @@ run:
 lint:
 	npm run lint
 
+kill:
+	lsof -ti:3000 | xargs kill -9

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@react-google-maps/api": "^2.20.3",
+        "mdi-paths": "^0.0.2",
         "next": "15.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@types/google.maps": "^3.58.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -3832,6 +3834,12 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/mdi-paths": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/mdi-paths/-/mdi-paths-0.0.2.tgz",
+      "integrity": "sha512-UFtHqEP3NIYigPuEUgKHFAxfAAlZYIhVTX8eGsJGpsG9wSBybh9OoZYBXg0Rp6PUC41D47yBheRzSPX2sOrDKw==",
+      "license": "Apache License 2.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,11 +11,13 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "@react-google-maps/api": "^2.20.3",
+    "mdi-paths": "^0.0.2",
     "next": "15.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@types/google.maps": "^3.58.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -194,6 +194,7 @@ export default function Chat() {
                               suggestMessage.facilitys[0]?.longitude || 136.68282470468046,
                           }}
                           facilities={suggestMessage.facilitys}
+                          height="400px"
                         />
                       ) : (
                         <p>Loading map...</p> // ローディングメッセージの表示

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -105,7 +105,7 @@ export default function Chat() {
     sessionStorage.setItem("datePlan", JSON.stringify(suggestMessage));
 
     // セッションストレージに今までの会話内容を保存する
-    sessionStorage.setItem("chatLog",JSON.stringify(chatLog));
+    sessionStorage.setItem("chatLog", JSON.stringify(chatLog));
 
     // 画面遷移
     router.push("/planDetail");

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -222,9 +222,10 @@ export default function Chat() {
                     <div className="flex flex-row justify-center my-10">
                       <button
                         onClick={saveDatePlan}
-                        className="bg-red-400 p-3 rounded-full border-black border-2"
+                        className="bg-red-400 p-5 rounded-2xl border-black border-2 text-6xl"
                       >
-                        詳細確認ボタン
+                        {/* 詳細ページへのリンクを表すSVGアイコン */}
+                        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="currentColor" d="M15.5 12c2.5 0 4.5 2 4.5 4.5c0 .88-.25 1.71-.69 2.4l3.08 3.1L21 23.39l-3.12-3.07c-.69.43-1.51.68-2.38.68c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5m0 2a2.5 2.5 0 0 0-2.5 2.5a2.5 2.5 0 0 0 2.5 2.5a2.5 2.5 0 0 0 2.5-2.5a2.5 2.5 0 0 0-2.5-2.5M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h1v7l2.5-1.5L12 9V2h6a2 2 0 0 1 2 2v7.81A6.48 6.48 0 0 0 15.5 10A6.5 6.5 0 0 0 9 16.5c0 2.31 1.21 4.35 3.03 5.5z" /></svg>
                       </button>
                     </div>
                   </div>

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -237,7 +237,7 @@ export default function Chat() {
               ) : (
                 // roleがuserの場合（右寄せ）
                 <div className="flex flex-row-reverse w-full my-10">
-                  <div className="inline-block px-4 py-2 rounded-lg bg-red-100 text-black">
+                  <div className="inline-block px-4 py-2 rounded-2xl bg-red-100 text-black w-1/3">
                     <span>{msg.message}</span>
                   </div>
                 </div>

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -220,6 +220,7 @@ export default function Chat() {
                       )}
                     </div>
                     <div className="flex flex-row justify-center my-10">
+                      {/* デートプラン詳細ページへのリダイレクトを行うボタン */}
                       <button
                         onClick={saveDatePlan}
                         className="bg-red-400 p-5 rounded-2xl border-black border-2 text-6xl"

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -94,10 +94,21 @@ export default function Chat() {
     [suggestMessage]
   );
 
-  // sessionStrageに最新のデートプランを保存して画面遷移を行う関数
+  /**
+   * セッションストレージにチャット画面の情報を保存する関数
+   * 1. セッションストレージに最新のデートプランを保存する
+   * 2. セッションストレージに今までの対話内容を保存する
+   * 3. 画面遷移を行う
+   */
+  // セッションストレージに最新のデートプランを保存する
+  // セッションストレージに今までの対話内容を保存する
+  // 画面遷移を行う
   const saveDatePlan = () => {
     // セッションストレージにAIからのデートプラン情報を保存する
     sessionStorage.setItem("datePlan", JSON.stringify(suggestMessage));
+
+    // セッションストレージに今までの会話内容を保存する
+    sessionStorage.setItem("chatLog",JSON.stringify(chatMessages));
 
     // 画面遷移
     router.push("/planDetail");

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -120,8 +120,6 @@ export default function Chat() {
       // サーバーメッセージを状態として保存
       setSuggestMessage(suggest);
 
-      console.log("This is facilitys :", suggest.facilitys);
-      console.log("This is description :", suggest.description);
 
       // AIからのデートプラン提案内容を保存
       setChatLog((prev) => {

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -214,7 +214,7 @@ export default function Chat() {
                     <div>
                       {/* デートプランの説明 */}
                       {isLoaded ? (
-                        suggestMessage.description
+                        suggestMessage?.description
                       ) : (
                         <p>Loading Description...</p>
                       )}

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -100,9 +100,6 @@ export default function Chat() {
    * 2. セッションストレージに今までの対話内容を保存する
    * 3. 画面遷移を行う
    */
-  // セッションストレージに最新のデートプランを保存する
-  // セッションストレージに今までの対話内容を保存する
-  // 画面遷移を行う
   const saveDatePlan = () => {
     // セッションストレージにAIからのデートプラン情報を保存する
     sessionStorage.setItem("datePlan", JSON.stringify(suggestMessage));

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -100,7 +100,7 @@ export default function Chat() {
     sessionStorage.setItem("datePlan", JSON.stringify(suggestMessage));
 
     // 画面遷移
-    router.push("/detail");
+    router.push("/planDetail");
   }
 
   return (

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Messages, SuggestMessage, Message } from "@/types/api";
+import { ChatLog, SuggestMessage, Message } from "@/types/api";
 import CustomizedGoogleMap from "@/components/CustomizedGoogleMap";
 import { useRouter } from "next/navigation";
 
@@ -11,7 +11,7 @@ export default function Chat() {
   const router = useRouter();
 
   // ユーザーからのメッセージを格納する変数
-  const [chatMessages, setMessages] = useState<Messages>([]);
+  const [chatLog, saveChatLog] = useState<ChatLog>([]);
 
   // メッセージ送信フォームの入力内容を一時的に格納する変数
   const [input, setInput] = useState("");
@@ -23,7 +23,7 @@ export default function Chat() {
   const [isLoaded, setIsLoaded] = useState(false);
 
   // リクエストボディーを送信する関数を定義
-  const sendMessages = async () => {
+  const sendChatLog = async () => {
     // inputの中身を読み取り
     const trimmedInput = input.trim();
     if (!trimmedInput) return;
@@ -36,8 +36,8 @@ export default function Chat() {
     };
 
     // userメッセージを保存
-    const updatedMessages = [...chatMessages, userMessage]
-    setMessages(updatedMessages);
+    const updatedChatLog = [...chatLog, userMessage]
+    saveChatLog(updatedChatLog);
 
     // input変数の中身を空文字列で初期化
     setInput("");
@@ -51,7 +51,7 @@ export default function Chat() {
       const response = await fetch("http://localhost:8000/api/datePlan", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(updatedMessages),
+        body: JSON.stringify(updatedChatLog),
       });
 
       if (!response.ok) {
@@ -68,7 +68,7 @@ export default function Chat() {
 
 
       // AIからのデートプラン提案内容を保存
-      setMessages((prev) => [
+      saveChatLog((prev) => [
         ...prev,
         {
           role: "system",
@@ -105,7 +105,7 @@ export default function Chat() {
     sessionStorage.setItem("datePlan", JSON.stringify(suggestMessage));
 
     // セッションストレージに今までの会話内容を保存する
-    sessionStorage.setItem("chatLog",JSON.stringify(chatMessages));
+    sessionStorage.setItem("chatLog",JSON.stringify(chatLog));
 
     // 画面遷移
     router.push("/planDetail");
@@ -115,7 +115,7 @@ export default function Chat() {
     <div className="flex flex-col h-screen p-4 bg-red-50">
       {/* チャットエリア */}
       <div className="flex-grow overflow-y-auto bg-white p-4 rounded shadow">
-        {chatMessages?.map((msg, index) => (
+        {chatLog?.map((msg, index) => (
           <div key={index} className="mb-4">
             {msg.role === "system" ? (
               // roleがsystemの場合（左寄せ）
@@ -178,12 +178,12 @@ export default function Chat() {
             type="text"
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && sendMessages()}
+            onKeyDown={(e) => e.key === "Enter" && sendChatLog()}
             className="flex-grow p-2 border rounded-l shadow-sm text-black focus:outline-none"
             placeholder="メッセージを入力"
           />
           <button
-            onClick={sendMessages}
+            onClick={sendChatLog}
             className="px-4 py-2 bg-red-400 text-white rounded-r shadow hover:bg-blue-600"
           >
             {/* 矢印アイコン */}

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -169,7 +169,7 @@ export default function Chat() {
   return (
     <div className="flex flex-col h-screen p-4 bg-red-50">
       {/* チャットエリア */}
-      <div className="flex-grow overflow-y-auto bg-white p-4 rounded shadow">
+      <div className="flex-grow overflow-y-auto bg-white p-4 rounded-lg shadow">
         {/* 描写開始条件 : isChatLogLoadedがtrueであること -> セッションストレージからのデータ読込が成功したこと */}
         {!isChatLogLoaded ? (
           <p className="text-gray-500">Loading chat history...</p>
@@ -179,7 +179,7 @@ export default function Chat() {
               {msg.role === "system" ? (
                 // roleがsystemの場合（左寄せ）
                 <div className="flex flex-row">
-                  <div className="inline-block px-4 py-4 rounded-lg bg-red-100 text-black w-4/5">
+                  <div className="inline-block px-4 py-4 rounded-2xl bg-red-100 text-black w-2/3">
                     <div>
                       {/* GoogleMapを表示 */}
                       {/* 一番最初に訪れる場所を初期レンダリング時の中心に据える */}
@@ -200,17 +200,21 @@ export default function Chat() {
                         <p>Loading map...</p> // ローディングメッセージの表示
                       )}
                     </div>
-                    <span>
+
+                    {/* 訪れる施設一覧 */}
+                    <div className="my-10">
                       {msg.facilitys?.map((facility, idx) => (
                         <div
                           key={idx}
-                          className="item bg-red-300 my-3 mx-0 p-3 rounded-lg"
+                          className="item bg-red-300 my-3 mx-4 px-6 py-5 font-bold text-xl rounded-2xl"
                         >
                           {facility.name}
                         </div>
                       ))}
-                    </span>
-                    <div>
+                    </div>
+                    <div
+                      className="mt-6 mx-5 mb-28"
+                    >
                       {/* デートプランの説明 */}
                       {isLoaded ? (
                         suggestMessage?.description
@@ -232,7 +236,7 @@ export default function Chat() {
                 </div>
               ) : (
                 // roleがuserの場合（右寄せ）
-                <div className="flex flex-row-reverse w-full">
+                <div className="flex flex-row-reverse w-full my-10">
                   <div className="inline-block px-4 py-2 rounded-lg bg-red-100 text-black">
                     <span>{msg.message}</span>
                   </div>

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -187,21 +187,21 @@ export default function Chat() {
                       {/* 一番最初に訪れる場所を初期レンダリング時の中心に据える */}
                       {suggestMessage && isLoaded ? (
                         <CustomizedGoogleMap
+                          // 万一緯度経度が読み込めなかったら、DMM金沢事業所がDefaultCenterとして表示される
                           center={{
                             name: suggestMessage.facilitys[0]?.name || "Default Center",
                             latitude:
-                              suggestMessage.facilitys[0]?.latitude || 36.5287888480469,
+                              suggestMessage.facilitys[0]?.latitude || 36.59438316927364,
                             longitude:
-                              suggestMessage.facilitys[0]?.longitude || 136.62829796528777,
+                              suggestMessage.facilitys[0]?.longitude || 136.68282470468046,
                           }}
                           facilities={suggestMessage.facilitys}
                         />
                       ) : (
-                        <p>Loading map...</p> // ローディング中の表示
+                        <p>Loading map...</p> // ローディングメッセージの表示
                       )}
                     </div>
                     <span>
-                      {/* Mapにピンを配置 */}
                       {msg.facilitys?.map((facility, idx) => (
                         <div
                           key={idx}

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -16,9 +16,6 @@ export default function Detail() {
   // 各拠点の近くの休憩場所(トイレ・コンビニ・カフェ)を保存する変数
   const [restAreas, setRestAreas] = useState<RestArea[]>([]);
 
-  // デートスポットのカードの開閉状態が変更されたかを管理する変数
-  // const [isChangedDateCardState, setIsChangedDateCardState] = useState<boolean>(false);
-
   // デートスポットのカードのうち、どのカードが変更されたかを管理する変数
   const [changedCardIndex, setChangedCardIndex] = useState<number>();
 
@@ -84,11 +81,6 @@ export default function Detail() {
   useEffect(() => {
     getRestArea();
   }, [getRestArea]);
-
-  // 疑問 : useEffectを複数記述してもよいか?
-  // プロットする休憩場所情報を更新する
-  // これだとどうなる？
-  // 実現したい事柄 : isChangedDateStateCardがtrueになったら.
 
 
   return (

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -100,14 +100,14 @@ export default function Detail() {
           {/* ボタンを押すとチャット画面にリダイレクトする */}
           <button
             onClick={() => { router.push("/chat") }}
-            className="bg-red-400 p-3 rounded-md border-black border-2 w-20 h-14 text-black text-2xl"
+            className="bg-red-400 p-3 rounded-xl border-black border-2 w-20 h-14 text-black text-2xl"
           >
             {/* リターン記号のUnicode */}
             &#x21A9;
           </button>
           {/* デートプランをPDFでダウンロードするボタン */}
           <button
-            className="bg-red-400 p-3 rounded-md border-black border-2 w-20 h-14 text-black text-2xl flex justify-center items-center"
+            className="bg-red-400 p-3 rounded-xl border-black border-2 w-20 h-14 text-black text-2xl flex justify-center items-center"
           >
             {/* ダウンロードアイコン */}
             <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="currentColor" d="M19.92 12.08L12 20l-7.92-7.92l1.42-1.41l5.5 5.5V2h2v14.17l5.5-5.51zM12 20H2v2h20v-2z" /></svg>

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -76,7 +76,6 @@ export default function Detail() {
 
   useEffect(() => {
     getRestArea();
-    console.log("Hello");
   }, [getRestArea]);
 
 

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -60,7 +60,7 @@ const Detail: React.FC = () => {
         </div>
 
         {/* 戻るボタンとか配置する場所 */}
-        <div className="h-1/6 md p-4 flex items-center justify-center bg-red-100">
+        <div className="h-1/6 md p-4 flex items-center justify-around bg-red-100">
           {/* ボタンを押すとチャット画面にリダイレクトする */}
           <button
             onClick={() => { router.push("/chat") }}

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -1,6 +1,5 @@
 'use client'
-import CustomizedGoogleMap from "@/components/CustomizedGoogleMap";
-import { Facility, SuggestMessage, RestArea } from "@/types/api";
+import CustomizedGoogleMap from "@/components/CustomizedGoogleMap"; import { Facility, SuggestMessage, RestArea } from "@/types/api";
 import { useRouter } from "next/navigation";
 import React, { useCallback, useEffect, useState } from "react";
 
@@ -8,7 +7,7 @@ import React, { useCallback, useEffect, useState } from "react";
 
 
 // デートプラン詳細ページの関数コンポーネント
-const Detail: React.FC = () => {
+export default function Detail() {
   // リダイレクトを実現するためにuseRouterを使う
   const router = useRouter();
 
@@ -48,7 +47,7 @@ const Detail: React.FC = () => {
 
 
   // 拠点情報から各々の近くの休憩所を検索する。APIの呼び出し
-  const getRestArea = async () => {
+  const getRestArea = useCallback(async () => {
     // APIエントリポイントにリクエスト
     for (const facility of facilities) {
       try {
@@ -63,13 +62,15 @@ const Detail: React.FC = () => {
         }
 
         const restArea: RestArea = await response.json();
+        console.log("休憩場所", restArea);
 
         // レスポンスボディーを保存
-        setRestAreas([...restAreas, restArea]);
+        setRestAreas((prev) => [...prev, restArea]);
       } catch (error) {
         console.error("Failed to fetch response:", error);
       }
-    };
+    }
+  }, [facilities]);
 
   // Todo : 
   //　画面リロード時に休憩場所を呼び出さないといけない
@@ -77,6 +78,7 @@ const Detail: React.FC = () => {
   // 新しいデータ構造作らないといけないかも
   useEffect(() => {
     getRestArea();
+    console.log("Hello");
   }, [getRestArea]);
 
 
@@ -123,6 +125,4 @@ const Detail: React.FC = () => {
       </div>
     </div>
   )
-}
-
-export default Detail;
+};

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -91,6 +91,7 @@ export default function Detail() {
         <div className="h-5/6 bg-red-100 p-6 overflow-y-scroll flex flex-col">
           {/* 地点情報カード */}
           {facilities.map((item, index) => (
+            // ドロップダウンメニュー
             <DropdownMenu menuTitle={item.name} restArea={restAreas[index]} key={index} />
           ))}
         </div>

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -1,0 +1,65 @@
+'use client'
+import CustomizedGoogleMap from "@/components/CustomizedGoogleMap";
+import { Facility, SuggestMessage } from "@/types/api";
+import React, { useEffect, useState } from "react";
+
+// デートプラン詳細ページの関数コンポーネント
+const Detail: React.FC = () => {
+  // セッションストレージからデータ読み出し
+  const [suggestDatePlan, setSuggestDatePlan] = useState<SuggestMessage | null>(null);
+
+  useEffect(() => {
+    try {
+      // セッションストレージからデータ読み出し
+      const storedData = sessionStorage.getItem("datePlan");
+      if (storedData) {
+        const parsedData = JSON.parse(storedData) as SuggestMessage;
+        setSuggestDatePlan(parsedData);
+      } else {
+        console.warn("セッションストレージにデータがありません。");
+      }
+    } catch (error) {
+      console.error("セッションストレージのデータ解析中にエラーが発生しました。", error);
+    }
+  }, []);
+
+  // 初期値（データが読み込まれる前に表示する内容）
+  const defaultFacilities: Facility[] = [];
+  const facilities = suggestDatePlan?.facilitys || defaultFacilities;
+
+
+  // Mapへの初期表示地点の中心点を決める
+  // セッションストレージから読み出したデータの先頭のものを使えばいい
+  const mapCenter: Facility = {
+    name: facilities[0]?.name,
+    latitude: facilities[0]?.latitude,
+    longitude: facilities[0]?.longitude,
+  };
+
+
+
+  return (
+    <div className="flex h-screen">
+      {/* 左側: デートプランの詳細情報 */}
+      <div className="w-1/2 bg-gray-100 p-6 overflow-y-scroll">
+
+        {/* 地点情報カード */}
+        {facilities.map((item, index) => (
+          <div
+            key={index}
+            className="bg-white shadow-md rounded-md p-4 mb-4"
+          >
+            <h2 className="text-xl font-semibold text-black">{item.name}</h2>
+          </div>
+        ))}
+      </div>
+
+      {/* 右側: Google Map */}
+      <div className="w-1/2">
+        <CustomizedGoogleMap center={mapCenter} facilities={facilities} />
+      </div>
+    </div>
+  )
+}
+
+export default Detail;

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -113,7 +113,7 @@ export default function Detail() {
 
       {/* 右側: Google Map */}
       <div className="w-1/2">
-        <CustomizedGoogleMap center={mapCenter} facilities={facilities} />
+        <CustomizedGoogleMap center={mapCenter} facilities={facilities} height="100vh"/>
       </div>
     </div>
   )

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -1,5 +1,7 @@
 'use client'
-import CustomizedGoogleMap from "@/components/CustomizedGoogleMap"; import { Facility, SuggestMessage, RestArea } from "@/types/api";
+import CustomizedGoogleMap from "@/components/CustomizedGoogleMap";
+import DropdownMenu from "@/components/DropDownMenu";
+import { Facility, SuggestMessage, RestArea } from "@/types/api";
 import { useRouter } from "next/navigation";
 import React, { useCallback, useEffect, useState } from "react";
 
@@ -86,16 +88,10 @@ export default function Detail() {
     <div className="flex h-screen">
       {/* 左側: デートプランの詳細情報 */}
       <div className="w-1/2 h-screen flex flex-col">
-        <div className="h-5/6 bg-red-100 p-6 overflow-y-scroll">
-
+        <div className="h-5/6 bg-red-100 p-6 overflow-y-scroll flex flex-col">
           {/* 地点情報カード */}
           {facilities.map((item, index) => (
-            <div
-              key={index}
-              className="bg-red-300 rounded-md p-4 mb-4"
-            >
-              <h2 className="text-xl font-semibold text-black">{item.name}</h2>
-            </div>
+            <DropdownMenu menuTitle={item.name} restArea={restAreas[index]} key={index} />
           ))}
         </div>
 

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -74,10 +74,6 @@ export default function Detail() {
     }
   }, [facilities]);
 
-  // Todo : 
-  //　画面リロード時に休憩場所を呼び出さないといけない
-  // 問題点facilitysには順序がない
-  // 新しいデータ構造作らないといけないかも
   useEffect(() => {
     getRestArea();
     console.log("Hello");

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -1,10 +1,14 @@
 'use client'
 import CustomizedGoogleMap from "@/components/CustomizedGoogleMap";
 import { Facility, SuggestMessage } from "@/types/api";
+import { useRouter } from "next/navigation";
 import React, { useEffect, useState } from "react";
 
 // デートプラン詳細ページの関数コンポーネント
 const Detail: React.FC = () => {
+  // リダイレクトを実現するためにuseRouterを使う
+  const router = useRouter();
+
   // セッションストレージからデータ読み出し
   const [suggestDatePlan, setSuggestDatePlan] = useState<SuggestMessage | null>(null);
 
@@ -41,17 +45,30 @@ const Detail: React.FC = () => {
   return (
     <div className="flex h-screen">
       {/* 左側: デートプランの詳細情報 */}
-      <div className="w-1/2 bg-gray-100 p-6 overflow-y-scroll">
+      <div className="w-1/2 h-screen flex flex-col">
+        <div className="h-5/6 bg-gray-100 p-6 overflow-y-scroll">
 
-        {/* 地点情報カード */}
-        {facilities.map((item, index) => (
-          <div
-            key={index}
-            className="bg-white shadow-md rounded-md p-4 mb-4"
+          {/* 地点情報カード */}
+          {facilities.map((item, index) => (
+            <div
+              key={index}
+              className="bg-white shadow-md rounded-md p-4 mb-4"
+            >
+              <h2 className="text-xl font-semibold text-black">{item.name}</h2>
+            </div>
+          ))}
+        </div>
+
+        {/* 戻るボタンとか配置する場所 */}
+        <div className="h-1/6 md p-4 flex justify-center bg-gray-100">
+          {/* ボタンを押すとチャット画面にリダイレクトする */}
+          <button
+            onClick={() => { router.push("/chat") }}
+            className="bg-red-400 p-3 rounded-full border-black border-2 w-36 h-14 text-black font-bold"
           >
-            <h2 className="text-xl font-semibold text-black">{item.name}</h2>
-          </div>
-        ))}
+            戻る
+          </button>
+        </div>
       </div>
 
       {/* 右側: Google Map */}

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -46,13 +46,13 @@ const Detail: React.FC = () => {
     <div className="flex h-screen">
       {/* 左側: デートプランの詳細情報 */}
       <div className="w-1/2 h-screen flex flex-col">
-        <div className="h-5/6 bg-gray-100 p-6 overflow-y-scroll">
+        <div className="h-5/6 bg-red-100 p-6 overflow-y-scroll">
 
           {/* 地点情報カード */}
           {facilities.map((item, index) => (
             <div
               key={index}
-              className="bg-white shadow-md rounded-md p-4 mb-4"
+              className="bg-red-300 rounded-md p-4 mb-4"
             >
               <h2 className="text-xl font-semibold text-black">{item.name}</h2>
             </div>
@@ -60,13 +60,21 @@ const Detail: React.FC = () => {
         </div>
 
         {/* 戻るボタンとか配置する場所 */}
-        <div className="h-1/6 md p-4 flex justify-center bg-gray-100">
+        <div className="h-1/6 md p-4 flex items-center justify-center bg-red-100">
           {/* ボタンを押すとチャット画面にリダイレクトする */}
           <button
             onClick={() => { router.push("/chat") }}
-            className="bg-red-400 p-3 rounded-full border-black border-2 w-36 h-14 text-black font-bold"
+            className="bg-red-400 p-3 rounded-md border-black border-2 w-20 h-14 text-black text-2xl"
           >
-            戻る
+            {/* リターン記号のUnicode */}
+            &#x21A9;
+          </button>
+          {/* デートプランをPDFでダウンロードするボタン */}
+          <button
+            className="bg-red-400 p-3 rounded-md border-black border-2 w-20 h-14 text-black text-2xl flex justify-center items-center"
+          >
+            {/* ダウンロードアイコン */}
+            <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="currentColor" d="M19.92 12.08L12 20l-7.92-7.92l1.42-1.41l5.5 5.5V2h2v14.17l5.5-5.51zM12 20H2v2h20v-2z" /></svg>
           </button>
         </div>
       </div>

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -16,6 +16,12 @@ export default function Detail() {
   // 各拠点の近くの休憩場所(トイレ・コンビニ・カフェ)を保存する変数
   const [restAreas, setRestAreas] = useState<RestArea[]>([]);
 
+  // デートスポットのカードの開閉状態が変更されたかを管理する変数
+  // const [isChangedDateCardState, setIsChangedDateCardState] = useState<boolean>(false);
+
+  // デートスポットのカードのうち、どのカードが変更されたかを管理する変数
+  const [changedCardIndex, setChangedCardIndex] = useState<number>();
+
   // セッションストレージから読み出したデートの行き先情報を格納する変数
   const [suggestDatePlan, setSuggestDatePlan] = useState<SuggestMessage | null>(null);
 
@@ -74,9 +80,15 @@ export default function Detail() {
     }
   }, [facilities]);
 
+
   useEffect(() => {
     getRestArea();
   }, [getRestArea]);
+
+  // 疑問 : useEffectを複数記述してもよいか?
+  // プロットする休憩場所情報を更新する
+  // これだとどうなる？
+  // 実現したい事柄 : isChangedDateStateCardがtrueになったら.
 
 
   return (
@@ -85,10 +97,19 @@ export default function Detail() {
       <div className="w-1/2 h-screen flex flex-col">
         <div className="h-5/6 bg-red-100 p-6 overflow-y-scroll flex flex-col">
           {/* 地点情報カード */}
-          {facilities.map((item, index) => (
-            // ドロップダウンメニュー
-            <DropdownMenu menuTitle={item.name} restArea={restAreas[index]} key={index} />
-          ))}
+          {facilities.map((item, index) => {
+            console.log(index, item.name);
+            return (
+              // ドロップダウンメニュー
+              <DropdownMenu
+                menuTitle={item.name}
+                restArea={restAreas[index]}
+                key={index}
+                cardIndex={index}
+                setChangedCardIndex={setChangedCardIndex}
+              />
+            )
+          })}
         </div>
 
         {/* 戻るボタンとか配置する場所 */}
@@ -113,7 +134,7 @@ export default function Detail() {
 
       {/* 右側: Google Map */}
       <div className="w-1/2">
-        <CustomizedGoogleMap center={mapCenter} facilities={facilities} height="100vh" />
+        <CustomizedGoogleMap center={mapCenter} facilities={facilities} height="100vh" restAreas={restAreas} changedCardIndex={changedCardIndex} />
       </div>
     </div>
   )

--- a/frontend/src/app/planDetail/page.tsx
+++ b/frontend/src/app/planDetail/page.tsx
@@ -113,7 +113,7 @@ export default function Detail() {
 
       {/* 右側: Google Map */}
       <div className="w-1/2">
-        <CustomizedGoogleMap center={mapCenter} facilities={facilities} height="100vh"/>
+        <CustomizedGoogleMap center={mapCenter} facilities={facilities} height="100vh" />
       </div>
     </div>
   )

--- a/frontend/src/components/CustomizedGoogleMap.tsx
+++ b/frontend/src/components/CustomizedGoogleMap.tsx
@@ -3,18 +3,22 @@
 import { GoogleMap, LoadScript, Marker } from "@react-google-maps/api";
 import { MapProps } from "@/types/customized.google.map";
 
+interface CustomizedGoogleMapProps extends MapProps {
+    height: string; // 高さを親から受け取る
+}
+
 
 // React.FCのFCはFunctionCompornentの意味
-const CustomizedGoogleMap: React.FC<MapProps> = ({ center, facilities }) => {
+const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facilities, height }) => {
 
     // Map形式
     const containerStyle = {
         width: "100%",
-        height: "100vh",
+        height: height,
     };
 
     // ズームレベル
-    const zoom = 13;
+    const zoom = 15;
 
 
     // APIキー読み出し

--- a/frontend/src/components/CustomizedGoogleMap.tsx
+++ b/frontend/src/components/CustomizedGoogleMap.tsx
@@ -82,7 +82,6 @@ const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facil
                                 lat: restAreas[changedCardIndex]?.cafe?.latitude,
                                 lng: restAreas[changedCardIndex]?.cafe?.longitude
                             }}
-                            // label={restAreas[changedCardIndex].cafe.name}
                             // カフェアイコン
                             icon={{
                                 fillColor: '#000000',
@@ -98,7 +97,6 @@ const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facil
                                 lat: restAreas[changedCardIndex]?.convenienceStore?.latitude,
                                 lng: restAreas[changedCardIndex]?.convenienceStore?.longitude
                             }}
-                            // label={restAreas[changedCardIndex].convenienceStore.name}
                             // コンビニアイコン
                             icon={{
                                 fillColor: '#000000',
@@ -114,7 +112,6 @@ const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facil
                                 lat: restAreas[changedCardIndex]?.toilet?.latitude,
                                 lng: restAreas[changedCardIndex]?.toilet?.longitude
                             }}
-                            // label={restAreas[changedCardIndex].toilet.name}
                             // トイレアイコン
                             icon={{
                                 fillColor: '#000000',

--- a/frontend/src/components/CustomizedGoogleMap.tsx
+++ b/frontend/src/components/CustomizedGoogleMap.tsx
@@ -33,10 +33,10 @@ const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facil
         console.log(i, element);
     }
 
-    // 緯度経度情報がnullの時のエラーハンドリング
+    // 緯度経度情報がnullの時の警告表示
     for (const facility of facilities) {
-        if ((facility.latitude === null || facility.longitude === null) || (facility.latitude === undefined || facility.longitude)) {
-            console.error("Error : 緯度か経度の情報が定義されていません");
+        if ((facility.latitude === null || facility.longitude === null) || (facility.latitude === undefined || facility.longitude === undefined)) {
+            console.warn("Error : 緯度か経度の情報が定義されていません");
         }
     }
 

--- a/frontend/src/components/CustomizedGoogleMap.tsx
+++ b/frontend/src/components/CustomizedGoogleMap.tsx
@@ -4,7 +4,6 @@
 import { GoogleMap, LoadScript, Marker } from "@react-google-maps/api";
 import { MapProps } from "@/types/customized.google.map";
 import { RestArea } from "@/types/api";
-import { useEffect } from "react";
 import { local_cafe, local_convenience_store, wc } from 'mdi-paths'
 
 
@@ -49,14 +48,10 @@ const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facil
 
 
 
-    // これでの実装は難しそう
-    useEffect(() => {
-        // restAreaをきちんと受け取ったかをチェックする
-        if (restAreas?.length === 0) {
-            console.warn("休憩場所の情報が取得できませんでした。", restAreas);
-        }
-
-    }, []);
+    // restAreaをきちんと受け取ったかをチェックする
+    if (restAreas?.length === 0) {
+        console.warn("休憩場所の情報が取得できませんでした。", restAreas);
+    }
 
     console.log("更新されました");
 

--- a/frontend/src/components/CustomizedGoogleMap.tsx
+++ b/frontend/src/components/CustomizedGoogleMap.tsx
@@ -1,15 +1,22 @@
 'use client';
 
+
 import { GoogleMap, LoadScript, Marker } from "@react-google-maps/api";
 import { MapProps } from "@/types/customized.google.map";
+import { RestArea } from "@/types/api";
+import { useEffect } from "react";
+import { local_cafe, local_convenience_store, wc } from 'mdi-paths'
+
 
 interface CustomizedGoogleMapProps extends MapProps {
-    height: string; // 高さを親から受け取る
+    height: string; // GoogleMapの画面上での縦幅
+    restAreas?: RestArea[]; // すべての休憩場所のデータ
+    changedCardIndex?: number; // 変更されたカードのindex情報
 }
 
 
 // React.FCのFCはFunctionCompornentの意味
-const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facilities, height }) => {
+const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facilities, height, restAreas, changedCardIndex }) => {
 
     // Map形式
     const containerStyle = {
@@ -36,9 +43,22 @@ const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facil
     // 緯度経度情報がnullの時の警告表示
     for (const facility of facilities) {
         if ((facility.latitude === null || facility.longitude === null) || (facility.latitude === undefined || facility.longitude === undefined)) {
-            console.warn("Error : 緯度か経度の情報が定義されていません");
+            console.warn("Warning : 緯度か経度の情報が定義されていません");
         }
     }
+
+
+
+    // これでの実装は難しそう
+    useEffect(() => {
+        // restAreaをきちんと受け取ったかをチェックする
+        if (restAreas?.length === 0) {
+            console.warn("休憩場所の情報が取得できませんでした。", restAreas);
+        }
+
+    }, []);
+
+    console.log("更新されました");
 
 
     return (
@@ -56,6 +76,61 @@ const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facil
                         label={location.name} // 任意でラベル表示
                     />
                 ))}
+
+                {/* 休憩場所の情報が取得できているのならば */}
+                {/* 休憩場所のマーカーを描写 */}
+                {restAreas && changedCardIndex && (
+                    <div>
+                        {/* カフェのマーカー */}
+                        <Marker
+                            position={{
+                                lat: restAreas[changedCardIndex].cafe.latitude,
+                                lng: restAreas[changedCardIndex].cafe.longitude
+                            }}
+                            // label={restAreas[changedCardIndex].cafe.name}
+                            // カフェアイコン
+                            icon={{
+                                fillColor: '#000000',
+                                fillOpacity: 1,
+                                path: local_cafe,
+                                strokeColor: '#000000',
+                                strokeWeight: 1,
+                            }}
+                        />
+                        {/* コンビニのマーカー */}
+                        <Marker
+                            position={{
+                                lat: restAreas[changedCardIndex].convenienceStore.latitude,
+                                lng: restAreas[changedCardIndex].convenienceStore.longitude
+                            }}
+                            // label={restAreas[changedCardIndex].convenienceStore.name}
+                            // コンビニアイコン
+                            icon={{
+                                fillColor: '#000000',
+                                fillOpacity: 1,
+                                path: local_convenience_store,
+                                strokeColor: '#000000',
+                                strokeWeight: 1,
+                            }}
+                        />
+                        {/* トイレのマーカー */}
+                        <Marker
+                            position={{
+                                lat: restAreas[changedCardIndex].toilet.latitude,
+                                lng: restAreas[changedCardIndex].toilet.longitude
+                            }}
+                            // label={restAreas[changedCardIndex].toilet.name}
+                            // トイレアイコン
+                            icon={{
+                                fillColor: '#000000',
+                                fillOpacity: 1,
+                                path: wc,
+                                strokeColor: '#000000',
+                                strokeWeight: 1,
+                            }}
+                        />
+                    </div>
+                )}
             </GoogleMap>
         </LoadScript>
     );

--- a/frontend/src/components/CustomizedGoogleMap.tsx
+++ b/frontend/src/components/CustomizedGoogleMap.tsx
@@ -33,6 +33,13 @@ const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facil
         console.log(i, element);
     }
 
+    // 緯度経度情報がnullの時のエラーハンドリング
+    for (const facility of facilities) {
+        if ((facility.latitude === null || facility.longitude === null) || (facility.latitude === undefined || facility.longitude)) {
+            console.error("Error : 緯度か経度の情報が定義されていません");
+        }
+    }
+
 
     return (
         <LoadScript googleMapsApiKey={apiKey}>

--- a/frontend/src/components/CustomizedGoogleMap.tsx
+++ b/frontend/src/components/CustomizedGoogleMap.tsx
@@ -84,8 +84,8 @@ const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facil
                         {/* カフェのマーカー */}
                         <Marker
                             position={{
-                                lat: restAreas[changedCardIndex].cafe.latitude,
-                                lng: restAreas[changedCardIndex].cafe.longitude
+                                lat: restAreas[changedCardIndex]?.cafe?.latitude,
+                                lng: restAreas[changedCardIndex]?.cafe?.longitude
                             }}
                             // label={restAreas[changedCardIndex].cafe.name}
                             // カフェアイコン
@@ -100,8 +100,8 @@ const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facil
                         {/* コンビニのマーカー */}
                         <Marker
                             position={{
-                                lat: restAreas[changedCardIndex].convenienceStore.latitude,
-                                lng: restAreas[changedCardIndex].convenienceStore.longitude
+                                lat: restAreas[changedCardIndex]?.convenienceStore?.latitude,
+                                lng: restAreas[changedCardIndex]?.convenienceStore?.longitude
                             }}
                             // label={restAreas[changedCardIndex].convenienceStore.name}
                             // コンビニアイコン
@@ -116,8 +116,8 @@ const CustomizedGoogleMap: React.FC<CustomizedGoogleMapProps> = ({ center, facil
                         {/* トイレのマーカー */}
                         <Marker
                             position={{
-                                lat: restAreas[changedCardIndex].toilet.latitude,
-                                lng: restAreas[changedCardIndex].toilet.longitude
+                                lat: restAreas[changedCardIndex]?.toilet?.latitude,
+                                lng: restAreas[changedCardIndex]?.toilet?.longitude
                             }}
                             // label={restAreas[changedCardIndex].toilet.name}
                             // トイレアイコン

--- a/frontend/src/components/DropDownMenu.tsx
+++ b/frontend/src/components/DropDownMenu.tsx
@@ -1,7 +1,7 @@
-import { Facility } from "@/types/api";
+import { RestArea } from "@/types/api";
 import { useState } from "react";
 
-const DropdownMenu = (menuTitle: string, facilities: Facility[]) => {
+export default function DropdownMenu({ menuTitle, restArea }: { menuTitle: string; restArea: RestArea }) {
   const [isOpen, setIsOpen] = useState(false);
 
   const toggleMenu = () => {
@@ -9,11 +9,11 @@ const DropdownMenu = (menuTitle: string, facilities: Facility[]) => {
   };
 
   return (
-    <div className="relative inline-block text-left">
+    <div className="w-full flex flex-col">
       {/* メニューボタン */}
       <button
         onClick={toggleMenu}
-        className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+        className={`w-full bg-red-300 text-black py-4 px-5 text-left font-bold rounded-t-2xl mt-2 ${!isOpen ? "rounded-2xl" : ""}`}
       >
         {menuTitle}
       </button>
@@ -21,23 +21,31 @@ const DropdownMenu = (menuTitle: string, facilities: Facility[]) => {
       {/* メニュー */}
       {isOpen && (
         <div
-          className="absolute right-0 z-10 mt-2 w-56 origin-top-right bg-white border border-gray-300 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
           role="menu"
+          className="bg-green-100 p-2 text-black rounded-b-md"
         >
-          <div className="py-1" role="none">
-            {facilities.map((items, index) => (
-              <button
-                key={index}
-                className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-              >
-                {items.name}
-              </button>
-            ))}
-          </div>
+          <ul>
+            <li
+              className="m-2 bg-green-200 px-3 py-2 rounded-md font-bold text-gray-600"
+              role="menuitem"
+            >
+              {restArea.cafe?.name || "カフェ情報なし"}
+            </li>
+            <li
+              className="m-2 bg-green-200 px-3 py-2 rounded-md font-bold text-gray-600"
+              role="menuitem"
+            >
+              {restArea.convenienceStore?.name || "コンビニ情報なし"}
+            </li>
+            <li
+              className="m-2 bg-green-200 px-3 py-2 rounded-md font-bold text-gray-600"
+              role="menuitem"
+            >
+              {restArea.toilet?.name || "トイレ情報なし"}
+            </li>
+          </ul>
         </div>
       )}
     </div>
   );
-};
-
-export default DropdownMenu;
+}

--- a/frontend/src/components/DropDownMenu.tsx
+++ b/frontend/src/components/DropDownMenu.tsx
@@ -1,12 +1,31 @@
 import { RestArea } from "@/types/api";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-export default function DropdownMenu({ menuTitle, restArea }: { menuTitle: string; restArea: RestArea }) {
+export default function DropdownMenu({
+  cardIndex,
+  menuTitle,
+  restArea,
+  setChangedCardIndex
+}: {
+  cardIndex: number;
+  menuTitle: string,
+  restArea: RestArea,
+  setChangedCardIndex: Function
+}) {
   const [isOpen, setIsOpen] = useState(false);
 
   const toggleMenu = () => {
     setIsOpen(!isOpen);
   };
+
+  // トグルメニューが開かれたらこのメニューを更新する
+  useEffect(() => {
+    if (isOpen) {
+      setChangedCardIndex(cardIndex);
+    }
+  }, [isOpen]);
+
+  console.log("menuTitle", menuTitle, "restArea", restArea);
 
   return (
     <div className="w-full flex flex-col">

--- a/frontend/src/components/DropDownMenu.tsx
+++ b/frontend/src/components/DropDownMenu.tsx
@@ -50,21 +50,21 @@ export default function DropdownMenu({
               className="m-3 bg-green-200 px-5 py-3 rounded-xl font-bold text-black text-lg"
               role="menuitem"
             >
-              {restArea.cafe?.name || "カフェ情報なし"}
+              {restArea?.cafe?.name || "カフェ情報なし"}
             </li>
             {/* コンビニ情報 */}
             <li
               className="m-3 bg-green-200 px-5 py-3 rounded-xl font-bold text-black text-lg"
               role="menuitem"
             >
-              {restArea.convenienceStore?.name || "コンビニ情報なし"}
+              {restArea?.convenienceStore?.name || "コンビニ情報なし"}
             </li>
             {/* トイレ情報 */}
             <li
               className="m-3 bg-green-200 px-5 py-3 rounded-xl font-bold text-black text-lg"
               role="menuitem"
             >
-              {restArea.toilet?.name || "トイレ情報なし"}
+              {restArea?.toilet?.name || "トイレ情報なし"}
             </li>
           </ul>
         </div>

--- a/frontend/src/components/DropDownMenu.tsx
+++ b/frontend/src/components/DropDownMenu.tsx
@@ -13,7 +13,7 @@ export default function DropdownMenu({ menuTitle, restArea }: { menuTitle: strin
       {/* メニューボタン */}
       <button
         onClick={toggleMenu}
-        className={`w-full bg-red-300 text-black py-4 px-5 text-left font-bold rounded-t-2xl mt-2 ${!isOpen ? "rounded-2xl" : ""}`}
+        className={`w-full bg-red-300 text-black text-2xl py-5 px-6 text-left rounded-t-2xl mt-2 ${!isOpen ? "rounded-2xl" : ""}`}
       >
         {menuTitle}
       </button>
@@ -22,23 +22,23 @@ export default function DropdownMenu({ menuTitle, restArea }: { menuTitle: strin
       {isOpen && (
         <div
           role="menu"
-          className="bg-green-100 p-2 text-black rounded-b-md"
+          className="bg-green-100 p-2 text-black rounded-b-2xl"
         >
           <ul>
             <li
-              className="m-2 bg-green-200 px-3 py-2 rounded-md font-bold text-gray-600"
+              className="m-3 bg-green-200 px-5 py-3 rounded-xl font-bold text-black text-lg"
               role="menuitem"
             >
               {restArea.cafe?.name || "カフェ情報なし"}
             </li>
             <li
-              className="m-2 bg-green-200 px-3 py-2 rounded-md font-bold text-gray-600"
+              className="m-3 bg-green-200 px-5 py-3 rounded-xl font-bold text-black text-lg"
               role="menuitem"
             >
               {restArea.convenienceStore?.name || "コンビニ情報なし"}
             </li>
             <li
-              className="m-2 bg-green-200 px-3 py-2 rounded-md font-bold text-gray-600"
+              className="m-3 bg-green-200 px-5 py-3 rounded-xl font-bold text-black text-lg"
               role="menuitem"
             >
               {restArea.toilet?.name || "トイレ情報なし"}

--- a/frontend/src/components/DropDownMenu.tsx
+++ b/frontend/src/components/DropDownMenu.tsx
@@ -18,25 +18,29 @@ export default function DropdownMenu({ menuTitle, restArea }: { menuTitle: strin
         {menuTitle}
       </button>
 
-      {/* メニュー */}
+      {/* 休憩場所メニュー */}
       {isOpen && (
         <div
           role="menu"
           className="bg-green-100 p-2 text-black rounded-b-2xl"
         >
+          {/* 休憩場所情報 */}
           <ul>
+            {/* カフェ情報 */}
             <li
               className="m-3 bg-green-200 px-5 py-3 rounded-xl font-bold text-black text-lg"
               role="menuitem"
             >
               {restArea.cafe?.name || "カフェ情報なし"}
             </li>
+            {/* コンビニ情報 */}
             <li
               className="m-3 bg-green-200 px-5 py-3 rounded-xl font-bold text-black text-lg"
               role="menuitem"
             >
               {restArea.convenienceStore?.name || "コンビニ情報なし"}
             </li>
+            {/* トイレ情報 */}
             <li
               className="m-3 bg-green-200 px-5 py-3 rounded-xl font-bold text-black text-lg"
               role="menuitem"

--- a/frontend/src/components/DropDownMenu.tsx
+++ b/frontend/src/components/DropDownMenu.tsx
@@ -1,0 +1,43 @@
+import { Facility } from "@/types/api";
+import { useState } from "react";
+
+const DropdownMenu = (menuTitle: string, facilities: Facility[]) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleMenu = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div className="relative inline-block text-left">
+      {/* メニューボタン */}
+      <button
+        onClick={toggleMenu}
+        className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+      >
+        {menuTitle}
+      </button>
+
+      {/* メニュー */}
+      {isOpen && (
+        <div
+          className="absolute right-0 z-10 mt-2 w-56 origin-top-right bg-white border border-gray-300 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+          role="menu"
+        >
+          <div className="py-1" role="none">
+            {facilities.map((items, index) => (
+              <button
+                key={index}
+                className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+              >
+                {items.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DropdownMenu;

--- a/frontend/src/components/FacilityCard.tsx
+++ b/frontend/src/components/FacilityCard.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { Facility } from "@/types/api";
+import { RestArea } from "@/types/api";
+import { useState } from "react";
+
+
+// 詳細画面の休憩場所表示部分
+const FacilityCard = ({ facility, index }: { facility: Facility, index: number }) => {
+
+  // 各拠点の近くの休憩場所を格納する変数
+  const [restArea, setRestArea] = useState<RestArea>();
+
+  // 拠点情報から近くの休憩所を探索する。APIの呼び出し
+  const getRestArea = async () => {
+    // APIエントリポイントにリクエスト
+    try {
+      const response = await fetch("http://localhost:8000/api/datePlan/restArea", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(facility),
+      })
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status code : ${response.status}`);
+      }
+
+      const restArea: RestArea = await response.json();
+
+      // レスポンスボディーを保存
+      setRestArea(restArea);
+
+      return restArea;
+    } catch (error) {
+      console.error("Failed to fetch response:", error);
+    }
+  };
+  return (
+    <div
+      key={index}
+      className="bg-red-300 rounded-md p-4 mb-4"
+    >
+      <h2
+        onClick={getRestArea}
+        className="text-xl font-semibold text-black"
+      >{facility.name}</h2>
+      {restArea ? (
+        <div>
+          <div>{restArea?.cafe.name}</div>
+          <div>{restArea?.convenienceStore.name}</div>
+          <div>{restArea?.toilet.name}</div>
+        </div>
+      ) : (
+        <div>Loading...</div>
+      )}
+    </div>
+  );
+}
+
+export default FacilityCard;

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -21,7 +21,7 @@ export type Message = {
 }
 
 // 今までの会話内容を格納する型
-export type Messages = Message[];
+export type ChatLog = Message[];
 
 
 // AIからのデートプランの提案を格納する型

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -29,3 +29,10 @@ export type SuggestMessage = {
   facilitys: Facility[];
   description: string;
 };
+
+// 休憩場所の格納先
+export type RestArea = {
+  cafe: Facility;
+  toilet: Facility;
+  convenienceStore: Facility;
+};

--- a/makefile
+++ b/makefile
@@ -1,0 +1,4 @@
+.PHONY: kill
+
+kill:
+	lsof -ti:3000,8000 | xargs kill -9


### PR DESCRIPTION
# 画面
![image](https://github.com/user-attachments/assets/7016b6d2-b6b2-4b4c-b9da-319a23a1b682)

# 実装した機能
- 休憩スポットの位置情報をプロットできる


# 実装できていないこと

- メッセージの編集
- チャットがないときにチャット画面でなにか入力を促すメッセージを入れる
- 入力フォームで改行を行えるようにする。